### PR TITLE
add `toBeDisabled` matcher

### DIFF
--- a/lib/jasmine_dom_matchers.js
+++ b/lib/jasmine_dom_matchers.js
@@ -198,6 +198,10 @@
         return generateResults(actual.selected, prettify(actual), '', 'be selected');
       }),
 
+      toBeDisabled: withSingleElement(function(actual) {
+        return generateResults(actual.disabled, prettify(actual), '', 'be disabled');
+      }),
+
       toHaveClass: withSingleElement(function(actual, expected) {
         var pass = (Array.isArray(expected) ? expected : Array(expected))
           .every(function(expectedClass) { return hasClass(actual, expectedClass) });

--- a/spec/javascripts/MatchersSpec.js
+++ b/spec/javascripts/MatchersSpec.js
@@ -229,6 +229,12 @@ describe("Matchers", function() {
       expect($('<option>foo</option>')).not.toBeSelected();
     });
 
+    it('tests disabled', function() {
+      expect($('<option disabled="disabled">foo</option>')).toBeDisabled();
+      expect($('<option disabled>foo</option>')).toBeDisabled();
+      expect($('<option>foo</option>')).not.toBeDisabled();
+    });
+
     it('tests focus', function() {
       var focusedInput = $('<input class="focused" type="text">')[0];
       document.querySelector('#jasmine-content').appendChild(focusedInput);


### PR DESCRIPTION
I was looking for a way to verify that an element was being disabled properly, but `toHaveAttr` wasn't doing it quite right. Thankfully it was nice and obvious how to add a specific `toBeDisabled` matcher. Thanks!